### PR TITLE
Scale board to page size

### DIFF
--- a/qml/coastaldefence.qml
+++ b/qml/coastaldefence.qml
@@ -37,6 +37,26 @@ ApplicationWindow
     id: mainwin
     initialPage: Component { StartPage { } }
     cover: Qt.resolvedUrl("cover/CoverPage.qml")
+
+    function updateBoardSize() {
+        GameEngine.boardWidth = mainwin.width
+        // Ensure the tiles are square
+        GameEngine.boardHeight = GameEngine.gameAreaY * GameEngine.tileWidth
+
+        if ((GameEngine.boardHeight + 2 * GameEngine.tileHeight) > mainwin.height) {
+            // The board is too high to fit on the page
+            var avilableHeight = (mainwin.height / (GameEngine.gameAreaY + 2)) * GameEngine.gameAreaY
+            GameEngine.boardHeight = avilableHeight
+            // Ensure the tiles are square
+            GameEngine.boardWidth = GameEngine.gameAreaX * GameEngine.tileHeight
+        }
+    }
+
+    Component.onCompleted: updateBoardSize()
+
+    Connections {
+        target: mainwin
+        onWidthChanged: updateBoardSize()
+        onHeightChanged: updateBoardSize()
+    }
 }
-
-

--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -41,7 +41,7 @@ Page {
     property int player: GameEngine.getActivePlayer();
     property int weapon: GameEngine.getActiveWeapon();
     property int textsize: 25
-    property int boxsize: 60
+    property int boxsize: GameEngine.tileWidth
     property var shiplist: ["sub","ship","cruiser","carrier"]
     property bool shipinforetract: false
 
@@ -128,8 +128,8 @@ Page {
 //        }
 
         // Tell SilicaFlickable the height of its content.
-        contentHeight: GameEngine.gameAreaY()*boxsize+2*boxsize
-        contentWidth: GameEngine.gameAreaX()*boxsize
+        contentHeight: GameEngine.boardHeight + 2 * GameEngine.tileHeight
+        contentWidth: GameEngine.boardWidth
         //VerticalScrollDecorator{}
         //HorizontalScrollDecorator{}
 
@@ -138,15 +138,15 @@ Page {
         Column {
             id: gridcolumn
             x: 0
-            y: boxsize*2
+            y: 2 * GameEngine.tileHeight
             Grid {
                 id: maingrid
-                columns: GameEngine.gameAreaX()
-                rows: GameEngine.gameAreaY()
+                columns: GameEngine.gameAreaX
+                rows: GameEngine.gameAreaY
                 spacing: 0
                 Repeater {
                     id: elements
-                    model: GameEngine.gameAreaX()*GameEngine.gameAreaY()
+                    model: GameEngine.gameAreaX * GameEngine.gameAreaY
                     delegate: PlacingBlock {
                     }
                 }

--- a/qml/pages/PlacingBlock.qml
+++ b/qml/pages/PlacingBlock.qml
@@ -2,10 +2,10 @@ import QtQuick 2.0
 import Sailfish.Silica 1.0
 
 Rectangle {
-    width: 60
-    height: 60
-    property int xcoordinate: index % GameEngine.gameAreaX()
-    property int ycoordinate: Math.floor(index / GameEngine.gameAreaX())
+    width: GameEngine.tileWidth
+    height: GameEngine.tileHeight
+    property int xcoordinate: index % GameEngine.gameAreaX
+    property int ycoordinate: Math.floor(index / GameEngine.gameAreaX)
     color: (GameEngine.getMyAreaAt(xcoordinate,ycoordinate) === 1 ? "red" : GameEngine.getMyAreaAt(xcoordinate,ycoordinate) === 2 ? "black" : GameEngine.getMyAreaAt(xcoordinate,ycoordinate) === 3 ? Theme.highlightColor : "transparent")
     border.color: "white"
     border.width: 1

--- a/qml/pages/SecondPage.qml
+++ b/qml/pages/SecondPage.qml
@@ -39,7 +39,7 @@ Page {
     property bool destroyed: false
     property int hitx: 0
     property int hity: 0
-    property int boxsize: 60
+    property int boxsize: GameEngine.tileWidth
 
     // To enable PullDownMenu, place our content in a SilicaFlickable
     SilicaFlickable {
@@ -80,8 +80,8 @@ Page {
         }
 
         // Tell SilicaFlickable the height of its content.
-        contentHeight: GameEngine.gameAreaY()*boxsize+2*boxsize
-        contentWidth: GameEngine.gameAreaX()*boxsize
+        contentHeight: GameEngine.gameAreaY + (2 * GameEngine.tileHeight)
+        contentWidth: GameEngine.gameAreaX
         //VerticalScrollDecorator{}
 
         // Place our content in a Column.  The PageHeader is always placed at the top
@@ -89,15 +89,15 @@ Page {
         Column {
             id: gridcolumn2
             x: 0
-            y: boxsize*2
+            y: 2 * GameEngine.tileHeight
             Grid {
                 id: maingrid2
-                columns: GameEngine.gameAreaX()
-                rows: GameEngine.gameAreaY()
+                columns: GameEngine.gameAreaX
+                rows: GameEngine.gameAreaY
                 spacing: 0
                 Repeater {
                     id: elements2
-                    model: GameEngine.gameAreaX()*GameEngine.gameAreaY()
+                    model: GameEngine.gameAreaX * GameEngine.gameAreaY
                     delegate: ShootingBlock {
                     }
                 }
@@ -107,16 +107,16 @@ Page {
             id: shotinfo
             visible: false
             width: parent.width
-            height: boxsize*3
+            height: 3 * GameEngine.tileHeight
             border.width: 0
             radius: 0
             border.color: Theme.secondaryColor
             color: Theme.secondaryHighlightColor
             x: 0
-            y: boxsize*(-2)
+            y: (-2) * GameEngine.tileHeight
 
             Behavior on visible {
-                NumberAnimation { target: shotinfo; property: "y"; from: boxsize*(-2); to: 0; duration: 500; easing.type: Easing.InOutQuad }
+                NumberAnimation { target: shotinfo; property: "y"; from: (-2) * GameEngine.tileHeight; to: 0; duration: 500; easing.type: Easing.InOutQuad }
             }
 
             Label {
@@ -190,13 +190,13 @@ Page {
         onRunningChanged: {
             var realx = 0
             var realy = 0
-            for (var i = 0; i < GameEngine.gameAreaX()*GameEngine.gameAreaY() ; i++) {
+            for (var i = 0; i < GameEngine.gameAreaX * GameEngine.gameAreaY ; i++) {
 
-                realx = i % GameEngine.gameAreaX()
-                realy = Math.floor( i / GameEngine.gameAreaX())
+                realx = i % GameEngine.gameAreaX
+                realy = Math.floor( i / GameEngine.gameAreaX)
                 if(GameEngine.getAreaAt(realx,realy) === 2) {
-                    maingrid2.childAt(realx*60,realy*60).color = "black"
-                    console.log(realx + "," + realy + " is destroyed (" + realx*60 + "," + realy*60 + ") " + maingrid2.childAt(realx*60,realy*60).color  )
+                    maingrid2.childAt(realx * GameEngine.tileWidth, realy * GameEngine.tileHeight).color = "black"
+                    console.log(realx + "," + realy + " is destroyed (" + realx * GameEngine.tileWidth + "," + realy * GameEngine.tileHeight + ") " + maingrid2.childAt(realx * GameEngine.tileWidth, realy * GameEngine.tileHeight).color)
                 }
             }
             console.log("destroyrunning")

--- a/qml/pages/ShipInfo.qml
+++ b/qml/pages/ShipInfo.qml
@@ -83,8 +83,8 @@ Rectangle {
         opacity: 1.0
         x: 10
         y: boxsize
-        width: GameEngine.gameAreaX()*boxsize
-        height: boxsize*5+20
+        width: GameEngine.gameAreaX * boxsize
+        height: boxsize * 5 + 20
         Label {
             text: "WEAPONS"
         }

--- a/qml/pages/ShootingBlock.qml
+++ b/qml/pages/ShootingBlock.qml
@@ -2,10 +2,10 @@ import QtQuick 2.0
 import Sailfish.Silica 1.0
 
 Rectangle {
-    width: 60
-    height: 60
-    property int xcoordinate: index % GameEngine.gameAreaX()
-    property int ycoordinate: Math.floor(index / GameEngine.gameAreaX())
+    width: GameEngine.tileWidth
+    height: GameEngine.tileHeight
+    property int xcoordinate: index % GameEngine.gameAreaX
+    property int ycoordinate: Math.floor(index / GameEngine.gameAreaX)
     color: (GameEngine.getAreaAt(xcoordinate,ycoordinate) === 1 ? "red" : GameEngine.getAreaAt(xcoordinate,ycoordinate) === 2 ? "black" : GameEngine.getAreaAt(xcoordinate,ycoordinate) === 3 ? Theme.highlightColor : "transparent")
     border.color: "white"
     border.width: 1

--- a/src/GameEngine.cpp
+++ b/src/GameEngine.cpp
@@ -20,11 +20,12 @@
 GameEngine* GameEngine::iEngine = NULL;
 
 GameEngine::GameEngine(QObject *parent) :
-    QObject(parent)
+    QObject(parent),
+    iBoardWidth(9 * 60),
+    iBoardHeight(14 * 60),
+    iGameareaX(GAMEX),
+    iGameareaY(GAMEY)
 {
-        iGameareaX = GAMEX;
-        iGameareaY = GAMEY;
-
         for(int i = 0; i < GAMEX; i++) {
             for(int j = 0; j < GAMEY; j++)
                 iPlayer1Area[i][j] = iPlayer2Area[i][j] = 0;
@@ -433,12 +434,60 @@ void GameEngine::setIActivePlayer(const qint16 &value)
 }
 
 
-qint16 GameEngine::gameAreaX() {
+qint16 GameEngine::gameAreaX() const
+{
     return iGameareaX;
 }
 
-qint16 GameEngine::gameAreaY() {
+qint16 GameEngine::gameAreaY() const
+{
     return iGameareaY;
+}
+
+quint32 GameEngine::boardWidth() const
+{
+    return iBoardWidth;
+}
+
+quint32 GameEngine::boardHeight() const
+{
+    return iBoardHeight;
+}
+
+quint32 GameEngine::tileWidth() const
+{
+    // Round down
+    return (iBoardWidth / iGameareaX);
+}
+
+quint32 GameEngine::tileHeight() const
+{
+    // Round down
+    return (iBoardHeight / iGameareaY);
+}
+
+void GameEngine::setBoardWidth(quint32 width)
+{
+    if (iBoardWidth != width) {
+        quint32 previousTileWidth = tileWidth();
+        iBoardWidth = width;
+        emit boardWidthChanged();
+        if (previousTileWidth != tileWidth()) {
+            emit tileWidthChanged();
+        }
+    }
+}
+
+void GameEngine::setBoardHeight(quint32 height)
+{
+    if (iBoardHeight != height) {
+        quint32 previousTileHeight = tileHeight();
+        iBoardHeight = height;
+        emit boardHeightChanged();
+        if (previousTileHeight != tileHeight()) {
+            emit tileHeightChanged();
+        }
+    }
 }
 
 Ship* GameEngine::getShipAt(qint16 _x, qint16 _y) {

--- a/src/GameEngine.h
+++ b/src/GameEngine.h
@@ -15,6 +15,14 @@
 class GameEngine : public QObject
 {
     Q_OBJECT
+
+    Q_PROPERTY(quint32 boardWidth READ boardWidth WRITE setBoardWidth NOTIFY boardWidthChanged)
+    Q_PROPERTY(quint32 boardHeight READ boardHeight WRITE setBoardHeight NOTIFY boardHeightChanged)
+    Q_PROPERTY(quint32 tileWidth READ tileWidth NOTIFY tileWidthChanged)
+    Q_PROPERTY(quint32 tileHeight READ tileHeight NOTIFY tileHeightChanged)
+    Q_PROPERTY(quint16 gameAreaX READ gameAreaX NOTIFY gameAreaXChanged)
+    Q_PROPERTY(quint16 gameAreaY READ gameAreaY NOTIFY gameAreaYChanged)
+
 public:
     //explicit GameEngine(QObject *parent = 0);
     Q_INVOKABLE static GameEngine* initEngine();
@@ -25,8 +33,8 @@ public:
     Q_INVOKABLE QString getDestroyedShipImage(qint16 _x, qint16 _y);
 
     Q_INVOKABLE bool checkPosition(Ship* _ship, qint16 _x, qint16 _y);
-    Q_INVOKABLE qint16 gameAreaX();
-    Q_INVOKABLE qint16 gameAreaY();
+    qint16 gameAreaX() const;
+    qint16 gameAreaY() const;
 
     Q_INVOKABLE qint16 getActivePlayer() const;
     Q_INVOKABLE qint16 getGameState();
@@ -78,7 +86,21 @@ public:
     Q_INVOKABLE bool getDebug();
     Q_INVOKABLE void toggleDebug();
 
+    quint32 boardWidth() const;
+    quint32 boardHeight() const;
+    quint32 tileWidth() const;
+    quint32 tileHeight() const;
+
+    void setBoardWidth(quint32 width);
+    void setBoardHeight(quint32 height);
+
 signals:
+    void boardWidthChanged();
+    void boardHeightChanged();
+    void tileWidthChanged();
+    void tileHeightChanged();
+    void gameAreaXChanged();
+    void gameAreaYChanged();
 
 public slots:
 
@@ -87,6 +109,9 @@ private:
     void initGameArea();
 
     static GameEngine* iEngine;
+
+    quint32 iBoardWidth;
+    quint32 iBoardHeight;
 
     qint16 iGameareaX;
     qint16 iGameareaY;


### PR DESCRIPTION
Scales the playing area to match the page size. The board is scaled to
fit into the screen width/height using square tiles.

The GameEngine code is designed to allow for non-square tiles, but a
little more work is needed to support this on the UI side.